### PR TITLE
need to do special things when removing special types

### DIFF
--- a/src/microfiber.js
+++ b/src/microfiber.js
@@ -291,6 +291,20 @@ export class Microfiber {
     const originalSchema = this._cloneSchema()
 
     try {
+      // If we are removing a special type like a Query or Mutation or Subscription
+      // then there's some special stuff to do
+      if (typesAreSame(this.getQueryType() || {}, { kind, name })) {
+        delete this.queryTypeName
+        delete this.schema.queryType
+      } else if (typesAreSame(this.getMutationType() || {}, { kind, name })) {
+        delete this.mutationTypeName
+        delete this.schema.mutationType
+      } else if (typesAreSame(this.getSubscriptionType() || {}, { kind, name })) {
+        delete this.subscriptionTypeName
+        delete this.schema.subscriptionType
+      }
+
+      // Do this *after* the special stuff above, if necessary
       delete this.schema.types[typeIndex]
       delete this.typeToIndexMap[typeKey]
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -522,7 +522,7 @@ describe('index', function () {
     expect(findFieldOnType({ typeKind: KINDS.OBJECT, typeName: 'Mutation', fieldName: 'createYetAnotherType', response })).to.not.be.ok
 
     //********************************
-    // Remove the "" Subscription, which should remove the "RandomTypeOne" now that nothing
+    // Remove the "subscribeToMyTypeFieldStringChanges" Subscription, which should remove the "RandomTypeOne" now that nothing
     // references it
 
     // Make sure they're there to start with
@@ -538,6 +538,15 @@ describe('index', function () {
     //
     //
     //********************************
+
+
+    // Make sure that removing the Mutation type does some things
+    expect(findType({ kind: mutationType.kind, name: mutationType.name, response })).to.be.ok
+    expect(response.__schema.mutationType).to.be.ok
+    microfiber.removeType({ kind: mutationType.kind, name: mutationType.name })
+    response = microfiber.getResponse()
+    expect(findType({ kind: mutationType.kind, name: mutationType.name, response })).to.not.be.ok
+    expect(response.__schema.mutationType).to.not.be.ok
   })
 })
 


### PR DESCRIPTION
If removing, for example the `Mutation` type, there are some special things to do.