### PR TITLE
keep types that implement used interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "pub": "yarn prepare && npm publish",
     "pub:dry-run": "yarn prepare && npm publish --dry-run",
     "test:watch": "nodemon -x 'yarn test' --ignore dist/",
-    "test": "yarn prepare && yarn mocha --config ./test/mocha-config.js"
+    "test:debug:watch": "nodemon -x 'yarn test:debug' --ignore dist/",
+    "test": "yarn prepare && yarn mocha --config ./test/mocha-config.js",
+    "test:debug": "yarn test --node-option inspect=0.0.0.0:9223"
   },
   "dependencies": {
     "lodash.defaults": "^4.2.0",


### PR DESCRIPTION
If an `INTERFACE` type was used as a field's value, but the implementation was not used, we would remove it...but really, we should keep it around since it is relevant by the fact that the `INTERFACE` means that it could be the possible returned type.